### PR TITLE
Unify mdsd source name for mdsd.syslog.** tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ The mdsd output plugin is a buffered fluentd plugin. Besides supporting all the 
 
   2) **acktimeoutms**: max time in milli-seconds to wait for mdsd acknowledge response. Before timeout, mdsd plugin will retry periodically to resend the events to mdsd. After timeout, the events holding in mdsd plugin memory will be dropped. If acktimeoutms is 0, the plugin won't do any failure retry if it cannot receives acknowledge from mdsd.
 
+  3) **mdsd_syslog_tag_prefix**: (Optional) Prefix of fluentd tags that should be treated as mdsd syslog messages. Default: nil.
+
+  4) **unify_mdsd_syslog_tags**: (Optional) If set, unify fluentd tags starting with the above prefix to just the prefix (this is the basic mdsd syslog messages uploading scenario). Default: false.
+
 ### Usage
 
 1) Install and configure mdsd. mdsd is a separate component. Please refer to related document.

--- a/src/fluent-plugin-mdsd/lib/fluent/plugin/out_mdsd.rb
+++ b/src/fluent-plugin-mdsd/lib/fluent/plugin/out_mdsd.rb
@@ -19,6 +19,10 @@ module Fluent
         config_param :djsonsocket, :string
         desc 'if no ack is received from mdsd after N milli-seconds, drop msg.'
         config_param :acktimeoutms, :integer
+        desc 'Fluentd tag prefix that will be treated as mdsd syslog messages'
+        config_param :mdsd_syslog_tag_prefix, :string, default: nil
+        desc 'If true, change (unify) any tags starting with the prefix to the prefix only'
+        config_param :unify_mdsd_syslog_tags, :bool, default: false
 
         # This method is called before starting.
         def configure(conf)
@@ -182,13 +186,15 @@ class MdsdMsgMaker
         return resultStr
     end
 
-    # Convert (unify) mdsd.syslog.** tags to mdsd.syslog so that mdsd sees only
-    # one single tag for all syslog messages. This is the use case for basic
-    # syslog messages collection. Also, it appears that tags can't be changed
-    # by a fluentd filter, so they need to be changed here in this output plugin.
+    # If configured, convert (unify) fluentd tags to a unified tag (prefix)
+    # so that mdsd sees only one single tag for all syslog messages. This is
+    # the use case for basic syslog messages collection. Also, it appears
+    # that tags can't be changed by a fluentd filter, so they need to be
+    # changed here in this output plugin.
     def create_mdsd_source(tag)
-        if tag.start_with?("mdsd.syslog.")
-            return "mdsd.syslog"
+        unify_tags = @unify_mdsd_syslog_tags and @mdsd_syslog_tag_prefix
+        if unify_tags and tag.start_with?(@mdsd_syslog_tag_prefix)
+            return @mdsd_syslog_tag_prefix
         return tag
 
     private

--- a/src/fluent-plugin-mdsd/out_mdsd_sample.conf
+++ b/src/fluent-plugin-mdsd/out_mdsd_sample.conf
@@ -4,6 +4,8 @@
     log_level info
     djsonsocket /var/run/mdsd/default_djson.socket  # Full path to mdsd dynamic json socket file
     acktimeoutms 5000  # max time in milli-seconds to wait for mdsd acknowledge response. If 0, no wait.
+    mdsd_syslog_tag_prefix "mdsdlog.syslog"  # (Optional) Prefix of fluentd tags that should be treated as mdsd syslog messages. Default: nil
+    unify_mdsd_syslog_tags true  # (Optional) If set, unify fluentd tags starting with the above prefix to just the prefix. Default: false
     num_threads 1
     buffer_chunk_limit 1000k
     buffer_type file


### PR DESCRIPTION
This is to avoid multiple source names in mdsd when uploading syslog messages through mdsd, on the basic scenario (uploading to one single table for all syslog messages).