### PR TITLE
Remove unnecessary syslog tag unification param

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ The mdsd output plugin is a buffered fluentd plugin. Besides supporting all the 
 
   2) **acktimeoutms**: max time in milli-seconds to wait for mdsd acknowledge response. Before timeout, mdsd plugin will retry periodically to resend the events to mdsd. After timeout, the events holding in mdsd plugin memory will be dropped. If acktimeoutms is 0, the plugin won't do any failure retry if it cannot receives acknowledge from mdsd.
 
-  3) **mdsd_syslog_tag_prefix**: (Optional) Prefix of fluentd tags that should be treated as mdsd syslog messages. Default: nil.
-
-  4) **unify_mdsd_syslog_tags**: (Optional) If set, unify fluentd tags starting with the above prefix to just the prefix (this is the basic mdsd syslog messages uploading scenario). Default: false.
+  3) **mdsd_syslog_tag_prefix**: (Optional) Prefix of fluentd tags that should be treated as
+mdsd syslog messages. This prefix will be used as the mdsd source name for all fluentd tags
+starting with this prefix. If this parameter is not specified, or for tags not starting with
+this prefix, the original fluentd tag will be used as the mdsd source name. Default: nil.
 
 ### Usage
 

--- a/src/fluent-plugin-mdsd/lib/fluent/plugin/out_mdsd.rb
+++ b/src/fluent-plugin-mdsd/lib/fluent/plugin/out_mdsd.rb
@@ -19,10 +19,8 @@ module Fluent
         config_param :djsonsocket, :string
         desc 'if no ack is received from mdsd after N milli-seconds, drop msg.'
         config_param :acktimeoutms, :integer
-        desc 'Fluentd tag prefix that will be treated as mdsd syslog messages'
+        desc 'Fluentd tag prefix that will be used as mdsd source name'
         config_param :mdsd_syslog_tag_prefix, :string, default: nil
-        desc 'If true, change (unify) any tags starting with the prefix to the prefix only'
-        config_param :unify_mdsd_syslog_tags, :bool, default: false
 
         # This method is called before starting.
         def configure(conf)
@@ -186,14 +184,13 @@ class MdsdMsgMaker
         return resultStr
     end
 
-    # If configured, convert (unify) fluentd tags to a unified tag (prefix)
-    # so that mdsd sees only one single tag for all syslog messages. This is
+    # If configured, convert (unify) fluentd tags to a unified tag (prefix) so that mdsd
+    # sees only one single tag (unique source name) for all syslog messages. This is
     # the use case for basic syslog messages collection. Also, it appears
     # that tags can't be changed by a fluentd filter, so they need to be
     # changed here in this output plugin.
     def create_mdsd_source(tag)
-        unify_tags = @unify_mdsd_syslog_tags and @mdsd_syslog_tag_prefix
-        if unify_tags and tag.start_with?(@mdsd_syslog_tag_prefix)
+        if @mdsd_syslog_tag_prefix and tag.start_with?(@mdsd_syslog_tag_prefix)
             return @mdsd_syslog_tag_prefix
         return tag
 

--- a/src/fluent-plugin-mdsd/out_mdsd_sample.conf
+++ b/src/fluent-plugin-mdsd/out_mdsd_sample.conf
@@ -4,8 +4,7 @@
     log_level info
     djsonsocket /var/run/mdsd/default_djson.socket  # Full path to mdsd dynamic json socket file
     acktimeoutms 5000  # max time in milli-seconds to wait for mdsd acknowledge response. If 0, no wait.
-    mdsd_syslog_tag_prefix "mdsdlog.syslog"  # (Optional) Prefix of fluentd tags that should be treated as mdsd syslog messages. Default: nil
-    unify_mdsd_syslog_tags true  # (Optional) If set, unify fluentd tags starting with the above prefix to just the prefix. Default: false
+    mdsd_syslog_tag_prefix "mdsdlog.syslog"  # (Optional) Prefix of fluentd tags that will be used as mdsd source name. Default: nil
     num_threads 1
     buffer_chunk_limit 1000k
     buffer_type file


### PR DESCRIPTION
(thanks to record_transformer filter)

Turns out that the fluentd record_transformer filter can be used to get the fields we (mdsd syslog table) want, so no need for the boolean param, so removing.