### PR TITLE
Add Time type to MessagePack packer and unpacker

### DIFF
--- a/src/fluent-plugin-mdsd/lib/fluent/plugin/out_mdsd.rb
+++ b/src/fluent-plugin-mdsd/lib/fluent/plugin/out_mdsd.rb
@@ -1,7 +1,5 @@
 # This is Linux MDS/Geneva monitoring agent (mdsd) output plugin.
 # The plugin will send data to mdsd agent using Unix socket file.
-
-
 module Fluent
 
     class OutputMdsd < BufferedOutput
@@ -47,6 +45,11 @@ module Fluent
                 resend_interval_ms, conn_retry_timeout_ms)
             @mdsdTagPatterns = mdsd_tag_regex_patterns
             @configured_max_record_size = [max_record_size, MDSD_MAX_RECORD_SIZE].min
+
+            time_packer = Proc.new { |time| [time.to_f].pack("D") }
+            time_unpacker = Proc.new  { |data| Time.at(data.unpack('D')[0]) }
+            MessagePack::DefaultFactory.register_type( 0x7f, Time, packer: time_packer, unpacker: time_unpacker)
+            Fluent::Engine.instance_variable_set("@msgpack_factory", ::MessagePack::DefaultFactory)
         end
 
         # This method is called before starting.


### PR DESCRIPTION
Fixes issue #43 

I have not tested this locally as i cannot run the test suite on my mac. However, the following works in irb fine:

```ruby
    require "msgpack"
    packer = MessagePack::Packer.new
    unpacker = MessagePack::Unpacker.new

    time_packer = packer.register_type(0x7f, Time) { |time| [time.to_i].pack("N") }
    time_unpacker = unpacker.register_type(0x7f) { |data| Time.at(data.unpack('N')[0]) }
    MessagePack::DefaultFactory.register_type( 0x7f, Time, packer: time_packer, unpacker: time_unpacker)

    sample_event = ["some_tag", Time.now, {"message" => "something"}]
    packer.pack(sample_event)
    unpacker.feed_each(packer.to_s) { |record| puts record }
    # Outputs:
    #some_tag
    #2017-10-24 15:33:13 -0700
    #{"message"=>"something"}

```