### PR TITLE
map ruby integer type

### DIFF
--- a/src/fluent-plugin-mdsd/lib/fluent/plugin/out_mdsd.rb
+++ b/src/fluent-plugin-mdsd/lib/fluent/plugin/out_mdsd.rb
@@ -135,6 +135,7 @@ class SchemaManager
         {
             "TrueClass" => "FT_BOOL",
             "FalseClass" => "FT_BOOL",
+            "Integer" => "FT_INT64",
             "Fixnum" => "FT_INT64",
             "Bignum" => "FT_INT64",
             "Float" => "FT_DOUBLE",


### PR DESCRIPTION
Ruby 2.4 started to unify Fixnum and Bignum to Integer

https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released/

Fix #52 

@bradhav25 @julioct @sajayantony 