### PR TITLE
Add new configuration hash_to_json in output plugin

### DIFF
--- a/src/fluent-plugin-mdsd/README.md
+++ b/src/fluent-plugin-mdsd/README.md
@@ -1,0 +1,67 @@
+# Azure Linux monitoring agent (mdsd) output plugin for [Fluentd](http://fluentd.org)
+
+## Overview
+
+This is fluentd output plugin for Azure Linux monitoring agent (mdsd).  Mdsd is the Linux logging infrastructure for Azure services. It connects various log outputs to Azure monitoring service (Geneva warm path).
+
+The mdsd output plugin is a [buffered fluentd plugin](http://docs.fluentd.org/articles/buffer-plugin-overview).
+
+### Installation
+
+NOTE: The plugin gem must be installed using **fluent-gem**.
+
+Download the [gemfile](https://github.com/Azure/fluentd-plugin-mdsd/releases) to your computer. Assume it is saved to /path/to/gemfile.
+
+For td-agent, run
+
+    $sudo bash
+    $umask 22
+    $/opt/td-agent/embedded/bin/fluent-gem install /path/to/gemfile
+
+For oms-agent, run
+
+    $sudo bash
+    $umask 22
+    $/opt/microsoft/omsagent/ruby/bin/fluent-gem install /path/to/gemfile
+
+
+### Expected Data Formats
+
+The data records sent to this plugin are expected to be in a flat structure key-value pairs, where each value are primitive types like number, string, boolean, or time. Value types including Array, Hash, and Range will be dumped as strings.
+
+If this behavior doesn't meet your requirements, the recommended way is to create filter plugins for your data records.
+
+### Configuration
+
+[See configuration sample](./src/fluent-plugin-mdsd/out_mdsd_sample.conf)
+
+The mdsd output plugin is a buffered fluentd plugin. Besides supporting all the fluentd buffered plugin parameters, it supports the following required parameters
+
+- **log_level**: this is [standard fluentd per plugin log level](http://docs.fluentd.org/v0.12/articles/logging#per-plugin-log). Valid values are: fatal, error, warn, info, debug, trace.
+
+- **djsonsocket**: this is the full path to mdsd dynamic json socket file.
+
+- **acktimeoutms**: max time in milliseconds to wait for mdsd acknowledge response. Before timeout, mdsd plugin will retry periodically to resend the events to mdsd. After timeout, the events holding in mdsd plugin memory will be dropped. If acktimeoutms is 0, the plugin won't do any failure retry if it cannot receives acknowledge from mdsd.
+
+- **mdsd_tag_regex_patterns**: (Optional) An array of regex patterns for mdsd source name unification purpose. The passed will be matched against each regex, and if there's a match, the matched substring will be used as the resulting mdsd source name. For example, if the tag is `mdsd.ext_syslog.user.info` and the regex is `^mdsd\.ext_syslog\.\w+`, then `mdsd.ext_syslog.user` will be the mdsd source name. If this parameter is not specified, or for tags not matching any regexes in this array parameter, the original fluentd tag will be used as the mdsd source name. Default: `[]`.
+
+- **resend_interval_ms**: the interval in milliseconds that failed messages are resent to mdsd by this plugin. Default: 30,000.
+
+- **conn_retry_timeout_ms**: the timeout in milliseconds to do network connection retry when connecting to mdsd process failed. Default: 60,000.
+
+- **emit_timestamp_name**: the field name for the event emit time stamp. Default: "FluentdIngestTimestamp".
+
+- **use_source_timestamp**: use the timestamp in the record source. If false, sets the time to Time.now Default: true.
+
+- **convert_hash_to_json**: if this is set to true, then plugin will convert hash string to proper json before sending to mdsd. 
+  Input record with hash  {key => {"X"=>"Y"}} will be tranformed to {key => {"X":"Y"}}
+
+### Usage
+
+1. Install and configure mdsd. mdsd is a separate component. Please refer to related document.
+
+1. Install the mdsd output plugin following Installation section.
+
+1. Configure fluentd using mdsd as the output plugin. Configure fluentd using whatever input plugin you want to use.
+
+1. Start (or restart) fluentd daemon.

--- a/src/fluent-plugin-mdsd/lib/fluent/plugin/out_mdsd.rb
+++ b/src/fluent-plugin-mdsd/lib/fluent/plugin/out_mdsd.rb
@@ -1,6 +1,8 @@
 # This is Linux MDS/Geneva monitoring agent (mdsd) output plugin.
 # The plugin will send data to mdsd agent using Unix socket file.
 
+require "json"
+require "json/ext"
 
 module Fluent
 
@@ -34,6 +36,8 @@ module Fluent
         config_param :use_source_timestamp, :bool, :default => true
         desc "the maximum record size to emit. Cannot exceed #{MDSD_MAX_RECORD_SIZE}"
         config_param :max_record_size, :integer, :default => MDSD_MAX_RECORD_SIZE
+        desc "convert hash type to json string"
+        config_param :convert_hash_to_json, :bool, :default => false
 
         # This method is called before starting.
         def configure(conf)
@@ -42,7 +46,7 @@ module Fluent
             Liboutmdsdrb::InitLogger($log.out.path, true)
             Liboutmdsdrb::SetLogLevel($log.level.to_s)
 
-            @mdsdMsgMaker = MdsdMsgMaker.new(@log)
+            @mdsdMsgMaker = MdsdMsgMaker.new(@log, convert_hash_to_json)
             @mdsdLogger = Liboutmdsdrb::SocketLogger.new(djsonsocket, acktimeoutms,
                 resend_interval_ms, conn_retry_timeout_ms)
             @mdsdTagPatterns = mdsd_tag_regex_patterns
@@ -209,7 +213,8 @@ class SchemaManager
 end
 
 class MdsdMsgMaker
-    def initialize(logger)
+    def initialize(logger, hashtojson)
+        @hashtojson = hashtojson
         @logger = logger
         @schema_mgr = SchemaManager.new(@logger)
     end
@@ -264,17 +269,24 @@ class MdsdMsgMaker
 
     # Get formatted value string accepted by mdsd dynamic json protocol.
     def get_value_by_type(value)
-        if (value.kind_of? String)
+        
+        if (value.kind_of? String)            
             # Use 'dump' to do proper escape.
             return value.dump
-        elsif (value.kind_of? Array) || (value.kind_of? Hash) || (value.kind_of? Range)
+        elsif (value.kind_of? Array) || (value.kind_of? Hash) || (value.kind_of? Range)                        
             # Treat data structure as a string. Use 'dump' to do proper escape.
-            return value.to_s.dump
+            # If type is json and hashtojson is set to true, then first convert it to json and then use dump for proper escape.
+            if (@hashtojson) && (value.kind_of? Hash)
+                return value.to_json.to_str.dump
+            else
+                return value.to_s.dump
+            end
         elsif (value.kind_of? Time)
             return ('[' + value.tv_sec.to_s + "," + value.tv_nsec.to_s + ']')
         elsif value.nil?
             return "null".dump
         else
+            puts "Unknown type value:'#{value}'"
             return value.to_s
         end
     end

--- a/src/fluent-plugin-mdsd/out_mdsd_sample.conf
+++ b/src/fluent-plugin-mdsd/out_mdsd_sample.conf
@@ -14,4 +14,6 @@
     flush_interval 10s
     retry_limit 3
     retry_wait 10s
+    # convert hash value to valid json.
+    convert_hash_to_json true
 </match>

--- a/src/fluent-plugin-mdsd/test/plugin/test_out_mdsd.rb
+++ b/src/fluent-plugin-mdsd/test/plugin/test_out_mdsd.rb
@@ -169,7 +169,7 @@ end
 class MdsdMsgMakerTest < Test::Unit::TestCase
 
     def setup
-        @msg_maker = MdsdMsgMaker.new(nil)
+        @msg_maker = MdsdMsgMaker.new(nil, false)
     end
 
     def test_record()
@@ -214,6 +214,25 @@ class MdsdMsgMakerTest < Test::Unit::TestCase
         expectedStr = '1,[3,["arraykey","FT_STRING"],["hashkey","FT_STRING"],["rangekey","FT_STRING"],["emittime","FT_TIME"]],["[1]","{1=>2}","1...4",[123,0]]'
         assert_equal(expectedStr, schemaVal, "get_schema_value_str")
     end
+
+    def test_HashType()
+        @new_msgmkr = MdsdMsgMaker.new(nil, true)
+        record = 
+        {
+            "properties" => {"hello"=>"there"}
+        }
+
+        returnVal = @new_msgmkr.get_schema_value_str(record)
+        puts "returned value '#{returnVal}'"  
+        expectedStr = '1,[0,["properties","FT_STRING"]],["{\"hello\":\"there\"}"]'
+        assert_equal(expectedStr, returnVal, "get_schema_value_str")  
+
+        # send it to msgmkr object with hash_to_json set to false
+        returnVal = @msg_maker.get_schema_value_str(record)
+        expectedStr = '1,[0,["properties","FT_STRING"]],["{\"hello\"=>\"there\"}"]'
+        assert_equal(expectedStr, returnVal, "get_schema_value_str")  
+    end
+        
 
     def test_source_name_creator()
         regex_list = [ "^mdsd\.syslog", "^mdsd\.ext_syslog\.\\w+" ]


### PR DESCRIPTION
For shoebox integration, some partners want to send properties field as a proper json.
If they use fluentd , fluentd converts the data as hash type.
e.g "properties:"{"key":"value"} when is emitted by the customer, it is converted as 
"properties"=>{"key"=>"value"}. So we are adding optional configuration for customers to convert hash sets to proper json before ingesting into mdsd and Geneva.
