### PR TITLE
Updating the link to buffered plugin documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is fluentd output plugin for Azure Linux monitoring agent (mdsd).  Mdsd is the Linux logging infrastructure for Azure services. It connects various log outputs to Azure monitoring service (Geneva warm path).
 
-The mdsd output plugin is a [buffered fluentd plugin](http://docs.fluentd.org/articles/buffer-plugin-overview).
+The mdsd output plugin is a [buffered fluentd plugin](https://docs.fluentd.org/buffer#overview).
 
 ### Installation
 


### PR DESCRIPTION
The link to doc for buffered plugin in fluentd looks does not exist. Updating the link accordingly which points to the documentation of buffered pluigs in fluentd