### PR TITLE
Support for td-agent4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@
 - GCC version >= 4.8.4
 - Ruby 2.x with [OMS Linux Agent](https://github.com/Microsoft/OMS-Agent-for-Linux)
   or [Fluentd Agent](http://www.fluentd.org/download)
-- [SWIG](http://www.swig.org/) 3.0
+- [SWIG](http://www.swig.org/) 3.0 for td-agent3 or SWIG 4.0.2 for td-agent4
 
 ## How to build the code
 

--- a/src/buildall.sh
+++ b/src/buildall.sh
@@ -86,7 +86,7 @@ fi
 FindRubyPath()
 {
     if [ "${Target}" == "td" ]; then
-        if [ -z "/opt/td-agent/embedded/bin" ]; then
+        if [ -d "/opt/td-agent/embedded/bin" ]; then
             RubyBaseDir="/opt/td-agent/embedded/include/ruby-"
             RUBY_BIN_PATH=/opt/td-agent/embedded/bin
         else

--- a/src/buildall.sh
+++ b/src/buildall.sh
@@ -86,8 +86,13 @@ fi
 FindRubyPath()
 {
     if [ "${Target}" == "td" ]; then
-        RubyBaseDir="/opt/td-agent/embedded/include/ruby-"
-        RUBY_BIN_PATH=/opt/td-agent/embedded/bin
+        if [ -z "/opt/td-agent/embedded/bin" ]; then
+            RubyBaseDir="/opt/td-agent/embedded/include/ruby-"
+            RUBY_BIN_PATH=/opt/td-agent/embedded/bin
+        else
+            RubyBaseDir="/opt/td-agent/include/ruby-"
+            RUBY_BIN_PATH=/opt/td-agent/bin
+        fi
     elif [ "${Target}" == "oms" ]; then
         RubyBaseDir="/opt/microsoft/omsagent/ruby/include/ruby-"
         RUBY_BIN_PATH=/opt/microsoft/omsagent/ruby/bin

--- a/src/outmdsdrb/CMakeLists.txt
+++ b/src/outmdsdrb/CMakeLists.txt
@@ -12,7 +12,7 @@ include_directories(
 add_custom_command(
 PRE_BUILD
 OUTPUT ${CMAKE_SOURCE_DIR}/outmdsdrb/outmdsdrb_wrap.cxx
-COMMAND swig3.0 -c++ -ruby ${CMAKE_SOURCE_DIR}/outmdsdrb/outmdsdrb.i
+COMMAND swig -c++ -ruby ${CMAKE_SOURCE_DIR}/outmdsdrb/outmdsdrb.i
 DEPENDS ${CMAKE_SOURCE_DIR}/outmdsdrb/outmdsdrb.i
 )
 


### PR DESCRIPTION
1. Fix ruby path for td-agent4
2. Don't hardcode swig to swig3. Instead just use swig and let user install the proper version. Hardcoding to swig3 will break the 
build in td-agent4, since it requires swig 4.0.2.
3. Update CONTRIBUTION.md for swig requirement.